### PR TITLE
code-friendly PEWs

### DIFF
--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -24,15 +24,14 @@ public class PEWImageView extends ImageView {
 
     public boolean reverseX = false;
     public boolean reverseY = false;
-    public float scrollSpaceX = 0;
-    public float scrollSpaceY = 0;
     public boolean updateOnDraw = false;
     public boolean blockParallaxX = false;
     public boolean blockParallaxY = false;
 
     private int screenWidth;
     private int screenHeight;
-
+    private float scrollSpaceX = 0;
+    private float scrollSpaceY = 0;
     private float heightImageView;
     private float widthImageView;
 

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -10,6 +10,7 @@ import android.view.Display;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.animation.Interpolator;
+import android.view.animation.LinearInterpolator;
 import android.widget.ImageView;
 
 import com.fmsirvent.ParallaxEverywhere.Utils.InterpolatorSelector;
@@ -19,12 +20,15 @@ import java.lang.Override;
 /**
  * Created by fmsirvent on 03/11/14.
  */
-public class PEWImageView  extends ImageView {
+public class PEWImageView extends ImageView {
 
-    private boolean reverseX = false;
-    private boolean reverseY = false;
-    private float scrollSpaceX = 0;
-    private float scrollSpaceY = 0;
+    public boolean reverseX = false;
+    public boolean reverseY = false;
+    public float scrollSpaceX = 0;
+    public float scrollSpaceY = 0;
+    public boolean updateOnDraw = false;
+    public boolean blockParallaxX = false;
+    public boolean blockParallaxY = false;
 
     private int screenWidth;
     private int screenHeight;
@@ -32,22 +36,23 @@ public class PEWImageView  extends ImageView {
     private float heightImageView;
     private float widthImageView;
 
-    private boolean updateOnDraw = false;
+    private Interpolator interpolator = new LinearInterpolator();
 
-    private boolean blockParallaxX = false;
-    private boolean blockParallaxY = false;
+    private ViewTreeObserver.OnScrollChangedListener mOnScrollChangedListener = null;
+    private ViewTreeObserver.OnGlobalLayoutListener  mOnGlobalLayoutListener = null;
+    private ViewTreeObserver.OnDrawListener onDrawListener = null;
 
-    Interpolator interpolator = null;
-
-    ViewTreeObserver.OnScrollChangedListener mOnScrollChangedListener = null;
-    ViewTreeObserver.OnGlobalLayoutListener  mOnGlobalLayoutListener = null;
-    ViewTreeObserver.OnDrawListener onDrawListener = null;
+    public PEWImageView(Context context) {
+        super(context);
+        checkScale();
+    }
 
     public PEWImageView(Context context, AttributeSet attrs) {
         super(context, attrs);
         if (!isInEditMode()) {
             checkAttributes(attrs);
         }
+        checkScale();
     }
 
     public PEWImageView(Context context, AttributeSet attrs, int defStyle) {
@@ -55,6 +60,7 @@ public class PEWImageView  extends ImageView {
         if (!isInEditMode()) {
             checkAttributes(attrs);
         }
+        checkScale();
     }
 
     @Override
@@ -112,6 +118,31 @@ public class PEWImageView  extends ImageView {
         super.onDetachedFromWindow();
     }
 
+    private boolean checkScale() {
+        switch (getScaleType()) {
+            case CENTER:
+            case CENTER_CROP:
+            case CENTER_INSIDE:
+                return true;
+            case FIT_CENTER:
+                Log.d("ParallaxEverywhere", "Scale type firCenter unsupported");
+                break;
+            case FIT_END:
+                Log.d("ParallaxEverywhere", "Scale type fitEnd unsupported");
+                break;
+            case FIT_START:
+                Log.d("ParallaxEverywhere", "Scale type fitStart unsupported");
+                break;
+            case FIT_XY:
+                Log.d("ParallaxEverywhere", "Scale type fitXY unsupported");
+                break;
+            case MATRIX:
+                Log.d("ParallaxEverywhere", "Scale type matrix unsupported");
+                break;
+        }
+        return false;
+    }
+
     private void checkAttributes(AttributeSet attrs) {
         TypedArray arr = getContext().obtainStyledAttributes(attrs, R.styleable.PEWAttrs);
         int reverse = arr.getInt(R.styleable.PEWAttrs_reverse, 1);
@@ -135,28 +166,6 @@ public class PEWImageView  extends ImageView {
             case AttrConstants.REVERSE_BOTH:
                 reverseX = true;
                 reverseY = true;
-                break;
-        }
-
-        switch (getScaleType()) {
-            case CENTER:
-            case CENTER_CROP:
-            case CENTER_INSIDE:
-                break;
-            case FIT_CENTER:
-                Log.d("ParallaxEverywhere", "Scale type firCenter unsupported");
-                break;
-            case FIT_END:
-                Log.d("ParallaxEverywhere", "Scale type fitEnd unsupported");
-                break;
-            case FIT_START:
-                Log.d("ParallaxEverywhere", "Scale type fitStart unsupported");
-                break;
-            case FIT_XY:
-                Log.d("ParallaxEverywhere", "Scale type fitXY unsupported");
-                break;
-            case MATRIX:
-                Log.d("ParallaxEverywhere", "Scale type matrix unsupported");
                 break;
         }
 
@@ -280,21 +289,8 @@ public class PEWImageView  extends ImageView {
         }
     }
 
-    public float getScrollSpaceX() {
-        return scrollSpaceX;
+    public void setInterpolator(Interpolator interpol) {
+        interpolator = interpol;
     }
-
-    public void setScrollSpaceX(float scrollSpaceX) {
-        this.scrollSpaceX = scrollSpaceX;
-    }
-
-    public float getScrollSpaceY() {
-        return scrollSpaceY;
-    }
-
-    public void setScrollSpaceY(float scrollSpaceY) {
-        this.scrollSpaceY = scrollSpaceY;
-    }
-
 
 }

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWTextView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWTextView.java
@@ -9,6 +9,7 @@ import android.view.Display;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
 import android.view.animation.Interpolator;
+import android.view.animation.LinearInterpolator;
 import android.widget.TextView;
 
 import com.fmsirvent.ParallaxEverywhere.Utils.InterpolatorSelector;
@@ -17,21 +18,23 @@ import com.fmsirvent.ParallaxEverywhere.Utils.InterpolatorSelector;
  * Created by fmsirvent on 03/11/14.
  */
 public class PEWTextView extends TextView {
-    private boolean reverseX = false;
-    private boolean reverseY = false;
-    private int scrollSpaceX = 0;
-    private int scrollSpaceY = 0;
-    private boolean updateOnDraw = false;
-    private boolean blockParallaxX = false;
-    private boolean blockParallaxY = false;
+
+    public boolean reverseX = false;
+    public boolean reverseY = false;
+    public int scrollSpaceX = 0;
+    public int scrollSpaceY = 0;
+    public boolean updateOnDraw = false;
+    public boolean blockParallaxX = false;
+    public boolean blockParallaxY = false;
+
     private int screenHeight;
     private int screenWidth;
     private float heightView;
     private float widthView;
-    private Interpolator interpolator;
+    private Interpolator interpolator = new LinearInterpolator();
     private ViewTreeObserver.OnScrollChangedListener mOnScrollChangedListener = null;
     private ViewTreeObserver.OnGlobalLayoutListener mOnGlobalLayoutListener = null;
-    ViewTreeObserver.OnDrawListener onDrawListener = null;
+    private ViewTreeObserver.OnDrawListener onDrawListener = null;
 
     public PEWTextView(Context context) {
         super(context);
@@ -225,4 +228,9 @@ public class PEWTextView extends TextView {
             scrollTo(getScrollX(),value);
         }
     }
+
+    public void setInterpolator(Interpolator interpol) {
+        interpolator = interpol;
+    }
+
 }


### PR DESCRIPTION
I'm writing my app in scala with the macroid dsl for the GUI code but the views weren't code-friendly

* added interpolator setters
* set the default interpolator on class init (it was being set by InterpolatorSelector on checkAttributes which isn't called from code at all - this and no setters made it null)
* made the reverse\*, updateOnDraw, blockParallax\* and scrollSpace\* (for textview) ivars public