### PR TITLE
Gentle parallax animation on ImageView.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ TextView | PEWTextView
 Gradle dependencies:
 
 ```groovy
-compile 'com.fmsirvent:parallaxeverywhere:1.0.4'
+compile 'com.github.alexanderbezverhni:parallaxeverywhere:1.0.0'
 ```
 
 Code in layout:

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,31 +17,23 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-POM_NAME=ParallaxEverywhere
+POM_NAME=GentleParallaxEverywhere
 POM_ARTIFACT_ID=parallaxeverywhere
 POM_PACKAGING=aar
-VERSION_NAME=1.0.4
-VERSION_CODE=5
-GROUP=com.fmsirvent
+VERSION_NAME=1.0.0
+VERSION_CODE=1
+GROUP=com.github.alexanderbezverhni
 
-POM_DESCRIPTION=Widget with parallax effect on scroll.
-POM_URL=https://github.com/narfss/ParallaxEverywhere
-POM_SCM_URL=https://github.com/narfss/ParallaxEverywhere
-POM_SCM_CONNECTION=scm:git@github.com:narfss/parallaxeverywhere.git
-POM_SCM_DEV_CONNECTION=scm:git@github.com:narfss/parallaxeverywhere.git
+POM_DESCRIPTION=Widget with gentle parallax effect on scroll.
+POM_URL=https://github.com/alexanderbezverhni/ParallaxEverywhere
+POM_SCM_URL=https://github.com/alexanderbezverhni/ParallaxEverywhere
+POM_SCM_CONNECTION=scm:git@github.com:alexanderbezverhni/parallaxeverywhere.git
+POM_SCM_DEV_CONNECTION=scm:git@github.com:alexanderbezverhni/parallaxeverywhere.git
 POM_LICENCE_NAME=MIT license. See the LICENSE file for more info
 POM_LICENCE_URL=http://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
-POM_DEVELOPER_ID=narfss
-POM_DEVELOPER_NAME=Francisco M Sirvent
-
-signing.keyId=XXXXXX
-signing.password=XXXXXX
-signing.secretKeyRingFile=/home/narf/.gnupg/secring.gpg
-
-NEXUS_USERNAME=XXXXXX
-NEXUS_PASSWORD=XXXXXX
-
+POM_DEVELOPER_ID=alexanderbezverhni
+POM_DEVELOPER_NAME=Alexander Bezverhni
 
 SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots
 RELEASE_REPOSITORY_URL=https://oss.sonatype.org/service/local/staging/deploy/maven2

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -158,7 +158,7 @@ public class PEWImageView extends ImageView {
 
         float factor = arr.getFloat(R.styleable.PEWAttrs_factor, FACTOR_DEFAULT);
         if (factor != FACTOR_DEFAULT)
-		    setFactor(factor);
+            setFactor(factor);
 
         reverseX = false;
         reverseY = false;
@@ -224,37 +224,36 @@ public class PEWImageView extends ImageView {
                     break;
             }
 
-			scrollSpaceY = getScrollSpace(vheight, dnewHeight, factor);
-			scrollSpaceX = getScrollSpace(vwidth, dnewWidth, factor);
+            scrollSpaceY = getScrollSpace(vheight, dnewHeight, factor);
+            scrollSpaceX = getScrollSpace(vwidth, dnewWidth, factor);
         }
         applyParallax();
     }
 
-	private float getScrollSpace(int viewEdgeSize, float imageEdgeSize, float factor){
-		if (viewEdgeSize > imageEdgeSize){
-			return 0;
-		}
+    private float getScrollSpace(int viewEdgeSize, float imageEdgeSize, float factor){
+        if (viewEdgeSize > imageEdgeSize){
+            return 0;
+        }
 
-		float maxScrollSpace = imageEdgeSize - viewEdgeSize;
-		if (factor == FACTOR_DEFAULT) {
-			return maxScrollSpace;
-		}
+        float maxScrollSpace = imageEdgeSize - viewEdgeSize;
+        if (factor == FACTOR_DEFAULT) {
+            return maxScrollSpace;
+        }
 
-		float factored = viewEdgeSize * (factor - 1.0f);
-		return Math.min(factored, maxScrollSpace);
-	}
+        float factored = viewEdgeSize * (factor - 1.0f);
+        return Math.min(factored, maxScrollSpace);
+    }
 
     private void parallaxAnimation() {
         initSizeScreen();
 
         applyParallax();
-
     }
 
     private void initSizeScreen() {
         WindowManager wm = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
         Display display = wm.getDefaultDisplay();
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
             Point size = new Point();
             display.getSize(size);
             screenHeight = size.y;
@@ -298,7 +297,7 @@ public class PEWImageView extends ImageView {
     }
 
     private void setMyScrollX(int value) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             setScrollX(value);
         } else {
             scrollTo(value, getScrollY());
@@ -306,7 +305,7 @@ public class PEWImageView extends ImageView {
     }
 
     private void setMyScrollY(int value) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
             setScrollY(value);
         } else {
             scrollTo(getScrollX(),value);
@@ -349,6 +348,11 @@ public class PEWImageView extends ImageView {
         this.blockParallaxY = blockParallaxY;
     }
 
+    @Override
+    public void scrollTo(int x, int y) {
+        super.scrollTo(isBlockParallaxX() ? 0 : x, isBlockParallaxY() ? 0 : y);
+    }
+
     /**
      * Limit parallax distance to some relative value, to make parallax animation more gentle.<br>
      *     Example: for an ImageView with 400x300 dimensions, we set an image with 400x1000 dimensions.
@@ -367,10 +371,10 @@ public class PEWImageView extends ImageView {
 
     /**
      * Returns either {@value #FACTOR_DEFAULT} (default value, when none factor is applied) or value >= 1.0f.
-	 *
+     *
      * @return
      */
     public float getFactor(){
-		return factor;
+        return factor;
     }
 }

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -359,9 +359,8 @@ public class PEWImageView extends ImageView {
      *      must be larger or equal than 1.0f
      */
     public void setFactor(float factor) {
-        if(factor < 1.0f){
+        if (factor < 1.0f)
             throw new IllegalArgumentException("Factor value must be larger or equal than 1.0f !");
-        }
 
         this.factor = factor;
     }

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -366,9 +366,10 @@ public class PEWImageView extends ImageView {
     }
 
     /**
-     * Returns either {@value #FACTOR_DEFAULT} (default value, when none factor is applied) or value >= 1.0f.
+     * Get parallax animation bounds factor.
 	 *
      * @return
+     *     either {@value #FACTOR_DEFAULT} (default value, when none factor is applied) or value that is larger or equal to 1.0f.
      */
     public float getFactor(){
 		return factor;

--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWTextView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWTextView.java
@@ -280,4 +280,9 @@ public class PEWTextView extends TextView {
     public void setBlockParallaxY(boolean blockParallaxY) {
         this.blockParallaxY = blockParallaxY;
     }
+
+    @Override
+    public void scrollTo(int x, int y) {
+        super.scrollTo(isBlockParallaxX() ? 0 : x, isBlockParallaxY() ? 0 : y);
+    }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -27,5 +27,7 @@
             <enum name="overshoot" value="7" />
         </attr>
 
+        <attr name="factor" format="float"/>
+
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Limit parallax distance to some relative value, to make parallax animation more gentle.
 Example: for an ImageView with 400x300 dimensions, we set an image with 400x1000 dimensions.
Enabling Y axis animation, we will experience very "aggressive" animation, while image will be moved
by 600 pixels vertically. Setting factor to 1.5f will result in 150px diff: 300*1.5=150
