### PR TITLE
When PEWImageView is used as a item in RecyclerView or ListView with fixed image height

### DIFF
--- a/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
+++ b/library/src/main/java/com/fmsirvent/ParallaxEverywhere/PEWImageView.java
@@ -257,6 +257,8 @@ public class PEWImageView extends ImageView {
                 setMyScrollY((int) (Math.min(Math.max((0.5f - interpolatedScrollDeltaY), -0.5f), 0.5f) * -scrollSpaceY));
             else
                 setMyScrollY((int) (Math.min(Math.max((0.5f - interpolatedScrollDeltaY), -0.5f), 0.5f) * scrollSpaceY));
+        }else{
+            setMyScrollY(0);
         }
 
         if (scrollSpaceX != 0) {
@@ -271,6 +273,8 @@ public class PEWImageView extends ImageView {
             } else {
                 setMyScrollX((int) (Math.min(Math.max((0.5f - interpolatedScrollDeltaX), -0.5f), 0.5f) * scrollSpaceX));
             }
+        }else{
+            setMyScrollX(0);
         }
     }
 


### PR DESCRIPTION
The problem is when PEWImageView is included as a list item in RecyclerView or ListView with fixed PEWImageView layout_height say 200dp and a loading image is placed on the ImageView till the image is loaded from server, and we are using parallax_y for animating PEWIMAGE items vertically ..

Then if the image that came from server has higher width and less height,i.e. the bitmap when placed in the imageView will leave some empty space in vertical direction..

Then in that case, the 'scrollSpaceY' instance variable of PEWImageView class is 0.
But since earlier the placeholder image was present, the view has already been scrolled to some non zero value but now the view should be scrolled back to 0 since the scrollSpaceY value is zero now

Calling invalidate() or requestLayout() do not make any difference I have tried all of them.

The solution is checking for 'scrollSpaceY' in applyParallax() method.
If this variable is non zero, perform scrolling on view
But if this is zero, reset view scroll to 0 to remove changes made on the view due to the placeholder image...Since placeholder image was big enough to make view scroll.
